### PR TITLE
Exception data and stack trace in xunit

### DIFF
--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -7,8 +7,12 @@ open Xunit
 open Xunit.Sdk
 open FsCheck
 
-type PropertyFailedException(testResult:FsCheck.TestResult) = 
-    inherit AssertException(sprintf "%s%s" Environment.NewLine (Runner.onFinishedToString "" testResult), "Sorry, no stack trace.")
+type PropertyFailedException = 
+    inherit AssertException
+    new (testResult:FsCheck.TestResult) = {
+        inherit AssertException(sprintf "%s%s" Environment.NewLine (Runner.onFinishedToString "" testResult), "Sorry, no stack trace.") }
+    new (userMessage, innerException : exn) = {
+        inherit AssertException(userMessage, innerException) }
 
 //can not be an anonymous type because of let mutable.
 type private XunitRunner() =

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -111,6 +111,9 @@ type PropertyAttribute() =
                     upcast new PassedResult(methodInfo,this.DisplayName)
                 | TestResult.Exhausted testdata -> 
                     upcast new FailedResult(methodInfo,PropertyFailedException(xunitRunner.Result), this.DisplayName)
+                | TestResult.False (testdata, originalArgs, shrunkArgs, Outcome.Exception e, seed)  -> 
+                    let message = sprintf "%s%s" Environment.NewLine (Runner.onFailureToString "" testdata shrunkArgs seed)
+                    upcast new FailedResult(methodInfo, PropertyFailedException(message, e), this.DisplayName)
                 | TestResult.False (testdata, originalArgs, shrunkArgs, outcome, seed)  -> 
                     upcast new FailedResult(methodInfo, PropertyFailedException(xunitRunner.Result), this.DisplayName)
         } :> ITestCommand

--- a/src/FsCheck.Xunit/PropertyAttribute.fs
+++ b/src/FsCheck.Xunit/PropertyAttribute.fs
@@ -8,7 +8,7 @@ open Xunit.Sdk
 open FsCheck
 
 type PropertyFailedException(testResult:FsCheck.TestResult) = 
-    inherit AssertException(sprintf "%s%s" Environment.NewLine (Runner.onFinishedToString "" testResult), "sorry no stacktrace")
+    inherit AssertException(sprintf "%s%s" Environment.NewLine (Runner.onFinishedToString "" testResult), "Sorry, no stack trace.")
 
 //can not be an anonymous type because of let mutable.
 type private XunitRunner() =


### PR DESCRIPTION
The purpose of this pull request is to enable tooling (mainly, in my case, TestDriven.Net) to use the exception message from a test to navigate to the failing test.

If there are issues with this PR, please let me know how I can rectify them (if possible). While I personally think that some of the code could be formatted in a more readable way, I aimed for as little change as possible.

---

# Motivation

In the currently available version of FsCheck, create a new project with FsCheck.Xunit, and add the following code:

```F#
module Repro

open System
open FsCheck.Xunit

[<Property>]
let myTest (i : int) : unit =
    // Imagine that there's some test code here...

    // Imagine this is an assertion that throws an exception:
    raise (InvalidOperationException "Test failed!")
```

When you run this code, you get this output:

```
------ Test started: Assembly: Library1.dll ------

Test 'Repro.myTest' failed: 
Falsifiable, after 1 test (0 shrinks) (StdGen (1582530171,296009217)):
0
with exception:
System.InvalidOperationException: Test failed!
   at Microsoft.FSharp.Core.Operators.Raise[T](Exception exn)
   at Repro.myTest(Int32 i) in C:\Users\Mark\Desktop\Library1\Library1\Library1.fs:line 11
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at FsCheck.Runner.invokeAndThrowInner@296-1.Invoke(Object[] o) in C:\Users\Kurt\Projects\FsCheck\fsharp\src\FsCheck\Runner.fs:line 298
   at <StartupCode$FSharp-Core>.$Reflect.Invoke@958-4.Invoke(T1 inp)
   at FsCheck.Testable.evaluate[a,b](FSharpFunc`2 body, a a) in C:\Users\Kurt\Projects\FsCheck\fsharp\src\FsCheck\Property.fs:line 171

            sorry no stacktrace

0 passed, 1 failed, 0 skipped, took 1,02 seconds (xUnit.net 1.9.2 build 1705).
```

The way the exception is formatted doesn't match the way xUnit.net normally formats an exception message. Specifically for the tooling I use (TestDriven.Net), it means

- The cursor doesn't automatically position itself on the line where the test failed (Repro.myTest).
- Even if I put the cursor on the failing line and hit Enter, nothing happens. I don't go to the test file, as I would expect.

I haven't investigate the impact this has on other tools (VS test runner, R#, NCrunch, etc.) but it may be the same issue there, since the exception is never correctly passed to xUnit.net in the expected format (as an Exception object).

# Resolution

By adding a special case when a property fails because of an exception, and populating xUnit.net's AssertException with the Exception object, the exception text is formatted as the tooling expects:

```
------ Test started: Assembly: Library1.dll ------

Test 'Repro.myTest' failed: 
Falsifiable, after 1 test (2 shrinks) (StdGen (74300383,296010394)):
0

---- System.InvalidOperationException : Test failed!
	
	----- Inner Stack Trace -----
	at Microsoft.FSharp.Core.Operators.Raise[T](Exception exn)
	C:\Users\Mark\Desktop\Library1\Library1\Library1.fs(16,0): at Repro.myTest(Int32 i)
	--- End of stack trace from previous location where exception was thrown ---
	at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
	c:\Users\Mark\Documents\FsCheck\src\FsCheck\Runner.fs(301,0): at FsCheck.Runner.invokeAndThrowInner@299-1.Invoke(Object[] o)
	at <StartupCode$FSharp-Core>.$Reflect.Invoke@958-4.Invoke(T1 inp)
	c:\Users\Mark\Documents\FsCheck\src\FsCheck\Testable.fs(161,0): at FsCheck.Testable.evaluate[a,b](FSharpFunc`2 body, a a)

0 passed, 1 failed, 0 skipped, took 1,06 seconds (xUnit.net 1.9.2 build 1705).

```

This means that now my cursor automatically sits on the offending line, and if I hit Enter, I'm taken to that line in Visual Studio.

This solves my problem.